### PR TITLE
Add URL of JNI library repository

### DIFF
--- a/src/main/resources/index.yml
+++ b/src/main/resources/index.yml
@@ -14,3 +14,5 @@
   - "io.github.mpetuska"
 "https://maven.pkg.github.com/mpetuska/npm-publish":
   - "lt.petuska"
+"https://gitlab.com/api/v4/projects/11000558/packages/maven":
+  - "io.github.commandertvis"


### PR DESCRIPTION
The repository: https://gitlab.com/CMDR_Tvis/jni
The API my library provides: https://cmdr_tvis.gitlab.io/jni/jni/io.github.commandertvis.jni/-j-n-i/index.html