### PR TITLE
Add sciprog center to repositories

### DIFF
--- a/src/main/resources/index.json
+++ b/src/main/resources/index.json
@@ -13,6 +13,10 @@
     "repo": "https://maven.pkg.jetbrains.space/spc/p/controls/maven"
   },
   {
+    "groupId": "center.sciprog",
+    "repo": "https://maven.pkg.jetbrains.space/spc/p/sci/maven"
+  },
+  {
     "groupId": "ru.mipt.npm",
     "repo": "https://maven.pkg.jetbrains.space/spc/p/mipt-npm/maven"
   },


### PR DESCRIPTION
Add sciprog.center (package name in https://github.com/SciProgCentre domain) to the list of redirects.